### PR TITLE
Add cd & ls commands

### DIFF
--- a/CLI/src/main/kotlin/ru/hse/egorov/command/CatCommand.kt
+++ b/CLI/src/main/kotlin/ru/hse/egorov/command/CatCommand.kt
@@ -1,12 +1,13 @@
 package ru.hse.egorov.command
 
-import java.io.File
+import ru.hse.egorov.environment.Environment
 import java.io.IOException
 
 /**
  * This class represents CLI cat command, which prints given files or previous command output.
  */
-class CatCommand : Command {
+class CatCommand(env: Environment) : Command {
+    private val environment = env
 
     override fun execute(args: List<String>, input: String): String {
         return if (args.isEmpty()) {
@@ -18,7 +19,7 @@ class CatCommand : Command {
 
     private fun readFile(filename: String): String {
         return try {
-            File(filename).readText()
+            environment.pathToFile(filename).readText()
         } catch (_: IOException) {
             FILE_READ_FAIL_MESSAGE_PREFIX + filename
         }

--- a/CLI/src/main/kotlin/ru/hse/egorov/command/CdCommand.kt
+++ b/CLI/src/main/kotlin/ru/hse/egorov/command/CdCommand.kt
@@ -1,0 +1,29 @@
+package ru.hse.egorov.command
+
+import ru.hse.egorov.environment.Environment
+
+/**
+ * This class represents the CLI command that changes the working directory to the given path.
+ */
+class CdCommand(env: Environment): Command {
+    private val environment = env
+
+    override fun execute(args: List<String>, input: String): String {
+        return if (args.size > 1) {
+            "cd: Too many arguments"
+        } else if (args.isEmpty()) {
+            environment.setWorkDir(environment.getHomeDir())
+            ""
+        } else {
+            val file = environment.pathToFile(args[0])
+            if (!file.exists()) {
+                "cd: " + args[0] + ": No such file or directory"
+            } else if (!file.isDirectory) {
+                "cd: " + args[0] + ": Not a directory"
+            } else {
+                environment.setWorkDir(file.absolutePath)
+                ""
+            }
+        }
+    }
+}

--- a/CLI/src/main/kotlin/ru/hse/egorov/command/CommandFactory.kt
+++ b/CLI/src/main/kotlin/ru/hse/egorov/command/CommandFactory.kt
@@ -13,7 +13,7 @@ class CommandFactory {
         fun getCommandByType(type: CommandToken.Companion.CommandType, env: Environment): Command {
             return when (type) {
                 GREP -> GrepCommand(env)
-                WC -> WcCommand()
+                WC -> WcCommand(env)
                 CAT -> CatCommand(env)
                 ECHO -> EchoCommand()
                 PWD -> PwdCommand(env)

--- a/CLI/src/main/kotlin/ru/hse/egorov/command/CommandFactory.kt
+++ b/CLI/src/main/kotlin/ru/hse/egorov/command/CommandFactory.kt
@@ -12,14 +12,16 @@ class CommandFactory {
     companion object {
         fun getCommandByType(type: CommandToken.Companion.CommandType, env: Environment): Command {
             return when (type) {
-                GREP -> GrepCommand()
+                GREP -> GrepCommand(env)
                 WC -> WcCommand()
-                CAT -> CatCommand()
+                CAT -> CatCommand(env)
                 ECHO -> EchoCommand()
-                PWD -> PwdCommand()
+                PWD -> PwdCommand(env)
                 EXIT -> ExitCommand()
                 ASSIGN_COMMAND -> AssignCommand(env)
-                else -> UnknownCommand()
+                CD -> CdCommand(env)
+                LS -> LsCommand(env)
+                else -> UnknownCommand(env)
             }
         }
     }

--- a/CLI/src/main/kotlin/ru/hse/egorov/command/GrepCommand.kt
+++ b/CLI/src/main/kotlin/ru/hse/egorov/command/GrepCommand.kt
@@ -2,14 +2,16 @@ package ru.hse.egorov.command
 
 import com.xenomachina.argparser.ArgParser
 import com.xenomachina.argparser.default
-import java.io.File
+import ru.hse.egorov.environment.Environment
 import java.io.IOException
+import java.nio.file.Paths
 
 /**
  * This class implements grep commands with following keys -- -i for case ignoring, -A n for showing n string after matching string,
  * -w for word matching.
  */
-class GrepCommand : Command {
+class GrepCommand(env: Environment) : Command {
+    private val environment = env
 
     override fun execute(args: List<String>, input: String): String {
         return ArgParser(args.toTypedArray()).parseInto(::GrepArgs).run {
@@ -56,7 +58,7 @@ class GrepCommand : Command {
 
     private fun processFile(filename: String, regex: Regex, isWordMatching: Boolean, afterContext: Int): String {
         return try {
-            processString(File(filename).readText(), regex, isWordMatching, afterContext)
+            processString(environment.pathToFile(filename).readText(), regex, isWordMatching, afterContext)
         } catch (_: IOException) {
             FILE_READ_FAIL_MESSAGE_PREFIX + "$filename\n"
         }

--- a/CLI/src/main/kotlin/ru/hse/egorov/command/LsCommand.kt
+++ b/CLI/src/main/kotlin/ru/hse/egorov/command/LsCommand.kt
@@ -1,0 +1,25 @@
+package ru.hse.egorov.command
+
+import ru.hse.egorov.environment.Environment
+import java.io.File
+
+/**
+ * This class represents the CLI command that prints list of files in the current directory.
+ */
+class LsCommand(env: Environment) : Command {
+    private val environment = env
+
+    override fun execute(args: List<String>, input: String): String {
+        if (args.size > 1) {
+            return "ls: Too many arguments"
+        }
+        val file : File = if (args.isEmpty()) { File(environment.getWorkDir()) } else { environment.pathToFile(args[0]) }
+        return if (!file.exists()) {
+            "ls: cannot access '" + args[0] + "': No such file or directory"
+        } else if (file.isDirectory) {
+            file.list().joinToString(" ", "", "\n") { it }
+        } else {
+            args[0] + "\n"
+        }
+    }
+}

--- a/CLI/src/main/kotlin/ru/hse/egorov/command/PwdCommand.kt
+++ b/CLI/src/main/kotlin/ru/hse/egorov/command/PwdCommand.kt
@@ -1,12 +1,14 @@
 package ru.hse.egorov.command
 
+import ru.hse.egorov.environment.Environment
 import java.io.File
 
 /**
  * This class prints files and directories in current directory.
  */
-class PwdCommand : Command {
+class PwdCommand(env: Environment) : Command {
+    private val environment = env
 
     override fun execute(args:List<String>, input: String): String =
-        File(".").list().joinToString(" ", "", "\n") { it }
+        File(environment.getWorkDir()).list().joinToString(" ", "", "\n") { it }
 }

--- a/CLI/src/main/kotlin/ru/hse/egorov/command/UnknownCommand.kt
+++ b/CLI/src/main/kotlin/ru/hse/egorov/command/UnknownCommand.kt
@@ -1,14 +1,22 @@
 package ru.hse.egorov.command
 
+import ru.hse.egorov.environment.Environment
+import java.io.File
+
 
 /**
  * This class tries to executed unknown command using external resources.
  */
-class UnknownCommand : Command {
+class UnknownCommand(env: Environment) : Command {
+    private val environment = env
 
     override fun execute(args: List<String>, input: String): String {
         return try {
-            val process = Runtime.getRuntime().exec(args.toTypedArray())
+            val process = Runtime.getRuntime().exec(
+                args.toTypedArray(),
+                environment.toStringSet().toTypedArray(),
+                File(environment.getWorkDir())
+            )
             process.outputStream.write(input.toByteArray())
             process.waitFor()
             process.inputStream.readBytes().toString()

--- a/CLI/src/main/kotlin/ru/hse/egorov/command/WcCommand.kt
+++ b/CLI/src/main/kotlin/ru/hse/egorov/command/WcCommand.kt
@@ -1,6 +1,6 @@
 package ru.hse.egorov.command
 
-import java.io.File
+import ru.hse.egorov.environment.Environment
 import java.io.IOException
 import java.nio.charset.Charset
 
@@ -8,7 +8,8 @@ import java.nio.charset.Charset
 /**
  * This class prints number of lines, words and bytes in given files or previous command result.
  */
-class WcCommand : Command {
+class WcCommand(env: Environment) : Command {
+    private val environment = env
 
     override fun execute(args: List<String>, input: String): String {
         return if (args.isEmpty()) {
@@ -20,7 +21,7 @@ class WcCommand : Command {
 
     private fun calcFileStatistics(filename: String): String {
         return try {
-            calcStatistics(File(filename).readBytes())
+            calcStatistics(environment.pathToFile(filename).readBytes())
         } catch (_: IOException) {
             FILE_READ_FAIL_MESSAGE_PREFIX + filename
         }

--- a/CLI/src/main/kotlin/ru/hse/egorov/environment/Environment.kt
+++ b/CLI/src/main/kotlin/ru/hse/egorov/environment/Environment.kt
@@ -1,5 +1,8 @@
 package ru.hse.egorov.environment
 
+import java.io.File
+import java.nio.file.Paths
+
 /**
  * This class represents available variables in CLI.
  */
@@ -9,4 +12,34 @@ class Environment {
     fun getVariable(name: String) = variables[name] ?: ""
 
     fun setVariable(key: String, value: String) = variables.set(key, value)
+
+    private fun isWindows() = System.getProperty("os.name").startsWith("Windows")
+
+    private fun getWorkDirVarName() : String = if (isWindows()) { "CD" } else { "PWD" }
+
+    private fun getHomeDirVarName() : String = if (isWindows()) { "USERPROFILE" } else { "HOME" }
+
+    init {
+        for ((k, v) in System.getenv()) {
+            setVariable(k, v)
+        }
+        setWorkDir(System.getProperty("user.dir"))
+    }
+
+    fun getWorkDir() = getVariable(getWorkDirVarName())
+
+    fun setWorkDir(path: String) = setVariable(getWorkDirVarName(), path)
+
+    fun getHomeDir() = getVariable(getHomeDirVarName())
+
+    fun toStringSet() = variables.entries.map { it.key + "=" + it.value }
+
+    fun pathToFile(path: String) : File {
+        val file = File(path)
+        return if (file.isAbsolute) {
+            file
+        } else {
+            Paths.get(getWorkDir(), path).toFile()
+        }
+    }
 }

--- a/CLI/src/main/kotlin/ru/hse/egorov/parser/CommandToken.kt
+++ b/CLI/src/main/kotlin/ru/hse/egorov/parser/CommandToken.kt
@@ -7,7 +7,7 @@ data class CommandToken(val type: CommandType, var args: String) {
 
     companion object {
         enum class CommandType {
-            GREP, STRING, CAT, ECHO, PWD, WC, EXIT, WEAK_QUOTE, STRONG_QUOTE, PARSE_COMMAND, UNKNOWN_COMMAND, ASSIGN_COMMAND;
+            GREP, STRING, CAT, ECHO, PWD, WC, EXIT, WEAK_QUOTE, STRONG_QUOTE, PARSE_COMMAND, UNKNOWN_COMMAND, ASSIGN_COMMAND, CD, LS;
 
             companion object {
                 fun getCommandByName(name: String): CommandType {

--- a/CLI/src/test/kotlin/ru/hse/egorov/command/CdCommandTest.kt
+++ b/CLI/src/test/kotlin/ru/hse/egorov/command/CdCommandTest.kt
@@ -1,0 +1,46 @@
+package ru.hse.egorov.command
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import ru.hse.egorov.environment.Environment
+import ru.hse.egorov.parser.CommandToken
+import java.io.File
+
+internal class CdCommandTest {
+    @Test
+    fun testCd() {
+        val env = Environment()
+        val cdCommand = CommandFactory.getCommandByType(CommandToken.Companion.CommandType.CD, env)
+        assertEquals("", cdCommand.execute(listOf("src"), ""))
+        assertEquals(File("src").absolutePath, File(env.getWorkDir()).absolutePath)
+    }
+
+    @Test
+    fun testCdNoArgs() {
+        val env = Environment()
+        val cdCommand = CommandFactory.getCommandByType(CommandToken.Companion.CommandType.CD, env)
+        assertEquals("", cdCommand.execute(listOf(), ""))
+        assertEquals(File(env.getHomeDir()).absolutePath, File(env.getWorkDir()).absolutePath)
+    }
+
+    @Test
+    fun testCdToUnexistentPath() {
+        val env = Environment()
+        val cdCommand = CommandFactory.getCommandByType(CommandToken.Companion.CommandType.CD, env)
+        assertTrue(cdCommand.execute(listOf("unexistent/path"), "").contains("No such file or directory"))
+    }
+
+    @Test
+    fun testCdToFile() {
+        val env = Environment()
+        val cdCommand = CommandFactory.getCommandByType(CommandToken.Companion.CommandType.CD, env)
+        assertTrue(cdCommand.execute(listOf("src/test/resources/test.txt"), "").contains("Not a directory"))
+    }
+
+    @Test
+    fun testTwoArgsToCd() {
+        val env = Environment()
+        val cdCommand = CommandFactory.getCommandByType(CommandToken.Companion.CommandType.CD, env)
+        assertTrue(cdCommand.execute(listOf("a", "b"), "").contains("Too many arguments"))
+    }
+}

--- a/CLI/src/test/kotlin/ru/hse/egorov/command/LsCommandTest.kt
+++ b/CLI/src/test/kotlin/ru/hse/egorov/command/LsCommandTest.kt
@@ -1,0 +1,42 @@
+package ru.hse.egorov.command
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import ru.hse.egorov.environment.Environment
+import ru.hse.egorov.parser.CommandToken
+
+class LsCommandTest {
+    private val environment = Environment()
+    private val lsCommand = CommandFactory.getCommandByType(CommandToken.Companion.CommandType.LS, environment)
+
+    @Test
+    fun testLs() {
+        val output = lsCommand.execute(listOf("src"), "")
+        assertTrue(output.contains("main"))
+        assertTrue(output.contains("test"))
+    }
+
+    @Test
+    fun testLsNoArgs() {
+        val output = lsCommand.execute(listOf(), "")
+        assertTrue(output.contains("src"))
+    }
+
+    @Test
+    fun testLsTwoArgs() {
+        val output = lsCommand.execute(listOf("a", "b"), "")
+        assertTrue(output.contains("Too many arguments"))
+    }
+
+    @Test
+    fun testLsUnexistentPath() {
+        val output = lsCommand.execute(listOf("unexistent/path"), "")
+        assertTrue(output.contains("No such file or directory"))
+    }
+
+    @Test
+    fun testLsFile() {
+        val output = lsCommand.execute(listOf("src/test/resources/test.txt"), "")
+        assertEquals("src/test/resources/test.txt\n", output)
+    }
+}

--- a/CLI/src/test/kotlin/ru/hse/egorov/environment/EnvironmentTest.kt
+++ b/CLI/src/test/kotlin/ru/hse/egorov/environment/EnvironmentTest.kt
@@ -25,4 +25,11 @@ internal class EnvironmentTest {
         env.setVariable("a", "c")
         assertEquals("c", env.getVariable("a"))
     }
+
+    @Test
+    fun testAssignWorkDir() {
+        val env = Environment()
+        env.setWorkDir("some/path")
+        assertEquals("some/path", env.getWorkDir())
+    }
 }


### PR DESCRIPTION
Что понравилось:

* Простота написания новых комманд. Отнаследовать класс от интерфейса и добавить пару строчек в фабрику. Это приятно.

Что не понравилось:

* Баги. Сейчас вывод от внешних команд не работает вообще. Это мешает в дебаге.
* pwd делает не то, что должен.

Замечания по архитектуре:

* На мой взгляд, тип команды - это сущность не из области парсера, а из области команды. Как минимум, тип команды гораздо чаще используется именно там, что приводит к длинным колбасам, ссылающимся на LS из какого-то класса другого пакета. Идейно, парсер не должен разбираться в том, внутренняя это команда или внешняя.
* Конструкторы у команд не унифицированы - не слишком удобно добираться до Environment, если команда почему-то про него не знает.
* Несмотря на то, что cd и ls являются самыми базовыми командами, никаких действий по поддержке рабочей директории не заявлено, приходится всё делать в рамках этого pull request'а. Это нелогично по той причине, что добавление новых команд по идее не должно изменять код для исполнения внещних команд, тем более таким тупым образом, как добавлением туда лишних аргументов в вызов exec, а приходится.